### PR TITLE
Fix hashpass reference

### DIFF
--- a/app/auth/login.js
+++ b/app/auth/login.js
@@ -2,7 +2,7 @@
 
 // Dependencies
 const router = require('express').Router(); // Create a Router instance
-const hashPass = require('hashPass');
+const hashPass = require('hashpass');
 const uuidv1 = require('uuid/v1');
 
 // Require users auth controller

--- a/app/users/usersController.js
+++ b/app/users/usersController.js
@@ -2,7 +2,7 @@
 
 // Dependencies
 const router = require('express').Router(); // Create a Router instance
-const hashPass = require('hashPass');
+const hashPass = require('hashpass');
 const uuidv4 = require('uuid/v4');
 
 // Require User model


### PR DESCRIPTION
The docs define the reference as `require('hashPass');`, but the Node module is actually `hashpass`. Mac does not care about letter case, but Heroku does. This fix is required to deploy to Heroku.